### PR TITLE
chore: update C / C++ related extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   // See https://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
-    "che-incubator.cpptools",
-    "redhat.dependency-analytics"
+    "eclipse-cdt.cdt-gdb-vscode",
+    "llvm-vs-code-extensions.vscode-clangd"
   ]
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

This pull request
- removes deprecated `che-incubator.cpptools`
- removes `redhat.dependency-analytics` as not suitable for C/C++
- adds `eclipse-cdt.cdt-gdb-vscode` and `llvm-vs-code-extensions.vscode-clangd`

Solves https://issues.redhat.com/browse/CRW-3302

Use following URI to create a workspace with factory
https://github.com/vitaliy-guliy/c-plus-plus?che-editor=che-incubator/che-code/insiders
