### PR TITLE
set devfile's schemaVersion to 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: cpp
 components:


### PR DESCRIPTION
Updates devfile's schemaVersion to 2.2.2

Related issue: https://github.com/eclipse/che/issues/21985


![screenshot-devspaces apps sandbox-stage gb17 p1 openshiftapps com-2024 02 01-16_10_23](https://github.com/devspaces-samples/c-plus-plus/assets/1271546/fe43b940-d527-4932-b303-ec37aaf67117)




